### PR TITLE
jsonスキーマの更新(api)

### DIFF
--- a/app/models/mapModel.js
+++ b/app/models/mapModel.js
@@ -18,7 +18,8 @@ const SpotSchema = new Schema({
     },
     gate_node_ids: [Number],
     parent_spot_ids: [Number],
-    detail_map_id: Number,
+    detail_map_ids: [Number],
+    detail_map_level_names: [String],
     others: {
         description: String,
         attachment: [
@@ -67,7 +68,11 @@ const MapSchema = new Schema({
     node: [NodeSchema],
     edge: [EdgeSchema],
     parent_spot_id: Number
-});
+}, { _id: false});
+
+const MapArraySchema = new Schema({
+    maps: [MapSchema]
+})
 
 // スキーマをモデルとしてコンパイルし、それをモジュールとして扱えるようにする
-module.exports = mongoose.model('MapModel', MapSchema);
+module.exports = mongoose.model('MapModel', MapArraySchema);

--- a/app/route/v1/map/index.js
+++ b/app/route/v1/map/index.js
@@ -7,7 +7,7 @@ router.use('/', require('./map-api-root.js'));
 router.use('/', require('./map-api-id.js'));
 
 // 総合学習プラザのテストデータ作成用のルーティング
-router.use('/', require('./test-sougou-post.js/index.js'))
+router.use('/', require('./test-sougou-post.js'))
 
 //routerをモジュールとして扱う準備
 module.exports = router;

--- a/app/route/v1/map/test-sougou-post.js
+++ b/app/route/v1/map/test-sougou-post.js
@@ -2,18 +2,12 @@ const express = require('express');
 const router = express.Router();
 const MapModel = require('../../../models/mapModel.js');
 
-const sougou = require('../../../../test/test-examples/sougou-test-map-data.js/index.js')
+const sougou = require('../../../../test/test-examples/sougou-test-map-data.js')
 
 router.post('/', (req, res) => {
     let Map = new MapModel();
     console.log(sougou);
-    Map.id = sougou.id;
-    Map.name = sougou.name;
-    Map.bounds = sougou.bounds;
-    Map.spot = sougou.spot;
-    Map.node = sougou.node;
-    Map.edge = sougou.edge;
-    Map.parent_spot_id = sougou.parent_spot_id;
+    Map.maps = [sougou];
     console.log(Map);
 
     Map.save((err) => {

--- a/test/test-examples/example.js
+++ b/test/test-examples/example.js
@@ -1,114 +1,133 @@
 let allMaps = [
     {
-        "bounds": {
-            "top_l": {
-                "lat": 0,
-                "lon": 0
-            },
-            "bot_r": {
-                "lat": 1,
-                "lon": 1
-            }
-        },
         "_id": "5dad7ccf319357df1d9305a9",
-        "spots": [],
-        "nodes": [],
-        "edges": [],
-        "name": "example-map",
-        "__v": 0
+        "maps":[
+            {
+                "bounds": {
+                    "top_l": {
+                        "lat": 0,
+                        "lon": 0
+                    },
+                    "bot_r": {
+                        "lat": 1,
+                        "lon": 1
+                    }
+                },
+                "spots": [],
+                "nodes": [],
+                "edges": [],
+                "name": "example-map",
+                "__v": 0
+            }
+        ]
     },
     {
-        "bounds": {
-            "top_l": {
-                "lat": 0,
-                "lon": 0
-            },
-            "bot_r": {
-                "lat": 1,
-                "lon": 1
-            }
-        },
         "_id": "5dad7d0818b967dfa8dfc107",
-        "spots": [],
-        "nodes": [],
-        "edges": [],
-        "name": "example-map",
-        "__v": 0
+        "maps": [
+            {
+                "bounds": {
+                    "top_l": {
+                        "lat": 0,
+                        "lon": 0
+                    },
+                    "bot_r": {
+                        "lat": 1,
+                        "lon": 1
+                    }
+                },
+                "spots": [],
+                "nodes": [],
+                "edges": [],
+                "name": "example-map",
+                "__v": 0
+            }
+        ]
     },
     {
-        "bounds": {
-            "top_l": {
-                "lat": 0,
-                "lon": 0
-            },
-            "bot_r": {
-                "lat": 1,
-                "lon": 1
-            }
-        },
         "_id": "5dad7d68518d13e0b71312ba",
-        "spots": [],
-        "nodes": [],
-        "edges": [],
-        "name": "example-map",
-        "__v": 0
+        "maps": [
+            {
+                "bounds": {
+                    "top_l": {
+                        "lat": 0,
+                        "lon": 0
+                    },
+                    "bot_r": {
+                        "lat": 1,
+                        "lon": 1
+                    }
+                },
+                "spots": [],
+                "nodes": [],
+                "edges": [],
+                "name": "example-map",
+                "__v": 0
+            }
+        ]
     },
     {
-        "bounds": {
-            "top_l": {
-                "lat": 0,
-                "lon": 0
-            },
-            "bot_r": {
-                "lat": 1,
-                "lon": 1
-            }
-        },
         "_id": "5dad7dba347a84e13fd02058",
-        "spots": [],
-        "nodes": [],
-        "edges": [],
-        "name": "example-map",
-        "__v": 0
-    },
-    {
-        "bounds": {
-            "top_l": {
-                "lat": 0,
-                "lon": 0
+        "maps": [
+            {
+                "bounds": {
+                    "top_l": {
+                        "lat": 0,
+                        "lon": 0
+                    },
+                    "bot_r": {
+                        "lat": 1,
+                        "lon": 1
+                    }
+                },
+                "spots": [],
+                "nodes": [],
+                "edges": [],
+                "name": "example-map",
+                "__v": 0
             },
-            "bot_r": {
-                "lat": 1,
-                "lon": 1
+            {
+                "bounds": {
+                    "top_l": {
+                        "lat": 0,
+                        "lon": 0
+                    },
+                    "bot_r": {
+                        "lat": 1,
+                        "lon": 1
+                    }
+                },
+                "spots": [],
+                "nodes": [],
+                "edges": [],
+                "name": "example-map",
+                "__v": 0
             }
-        },
-        "_id": "5dafc6c1ecb7ff4fe8e9a159",
-        "spots": [],
-        "nodes": [],
-        "edges": [],
-        "name": "example-map",
-        "__v": 0
+        ]
     }
 ];
 
 let singleMap =
 {
-    "bounds": {
-        "top_l": {
-            "lat": 0,
-            "lon": 0
-        },
-        "bot_r": {
-            "lat": 1,
-            "lon": 1
-        }
-    },
     "_id": "5dad7ccf319357df1d9305a9",
-    "spots": [],
-    "nodes": [],
-    "edges": [],
-    "name": "example-map",
-    "__v": 0
+    "maps": [
+        {
+            "bounds": {
+                "top_l": {
+                    "lat": 0,
+                    "lon": 0
+                },
+                "bot_r": {
+                    "lat": 1,
+                    "lon": 1
+                }
+            },
+            "spots": [],
+            "nodes": [],
+            "edges": [],
+            "name": "example-map",
+            "__v": 0
+        }
+    ]
 };
 
 module.exports = {

--- a/test/test-examples/sougou-test-map-data.js
+++ b/test/test-examples/sougou-test-map-data.js
@@ -3,16 +3,15 @@ const sougou =
     "maps": [
         {
             "id": 0,
-            "name": "SougouGakusyuPlaza",
+            "name": "SougouGakusyuPlaza_1F",
             "spot": [
                 {
                     "id": 0,
-                    "name": 101,
+                    "name": "101",
                     "coordinate": {
                         "lat": 33.5954558,
                         "lng": 130.2179447
                     },
-                    "floor": 1,
                     "shape": {
                         "type": "Polygon",
                         "coordinates": [
@@ -22,27 +21,7 @@ const sougou =
                         ]
                     },
                     "gate_node_ids": [0],
-                },
-                {
-                    "id": 10,
-                    "name": 201,
-                    "coordinate": {
-                        "lat": 33.5954558,
-                        "lng": 130.2179447
-                    },
-                    "floor": 2,
-                    "shape": {
-                        "type": "Polygon",
-                        "coordinates": [
-                            [
-                                [130.217816, 33.595257], [130.217783, 33.595517], [130.217915, 33.595558], [130.217942, 33.595495]
-                            ]
-                        ]
-                    },
-                    "gate_node_ids": [10],
-                    "detail_map_ids": [],
-                    "others": {}
-                },
+                }
             ],
             "node": [
                 {
@@ -53,17 +32,6 @@ const sougou =
                         "lat": 33.5954558,
                         "lng": 130.2179447
                     },
-                    "floor": 1
-                },
-                {
-                    "id": 10,
-                    "map_id": 0,
-                    "spot_id": 10,
-                    "coordinate": {
-                        "lat": 33.5954558,
-                        "lng": 130.2179447
-                    },
-                    "floor": 2
                 },
             ],
             "edge": [
@@ -86,7 +54,45 @@ const sougou =
                     "lng": 130.2177802
                 }
             },
-        }
+        },
+        {
+            "id": 1,
+            "name": "SougouGakusyuPlaza_2F",
+            "spot": [
+                {
+                    "id": 10,
+                    "name": "201",
+                    "coordinate": {
+                        "lat": 33.5954558,
+                        "lng": 130.2179447
+                    },
+                    "shape": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [130.217816, 33.595257], [130.217783, 33.595517], [130.217915, 33.595558], [130.217942, 33.595495]
+                            ]
+                        ]
+                    },
+                    "gate_node_ids": [10],
+                    "detail_map_ids": [],
+                    "others": {}
+                }
+            ],
+            "node": [
+                {
+                    "id": 10,
+                    "map_id": 0,
+                    "spot_id": 10,
+                    "coordinate": {
+                        "lat": 33.5954558,
+                        "lng": 130.2179447
+                    },
+                }
+            ],
+            "edge": []
+        },
     ]
 }
+ 
 module.exports = sougou;

--- a/test/test-examples/sougou-test-map-data.js
+++ b/test/test-examples/sougou-test-map-data.js
@@ -1,88 +1,92 @@
-const sougou =
+const sougou = 
 {
-    "id": 0,
-    "name": "SougouGakusyuPlaza",
-    "spot": [
+    "maps": [
         {
             "id": 0,
-            "name": 101,
-            "coordinate": {
-                "lat": 33.5954558,
-                "lng": 130.2179447
+            "name": "SougouGakusyuPlaza",
+            "spot": [
+                {
+                    "id": 0,
+                    "name": 101,
+                    "coordinate": {
+                        "lat": 33.5954558,
+                        "lng": 130.2179447
+                    },
+                    "floor": 1,
+                    "shape": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [130.217816, 33.595257], [130.217783, 33.595517], [130.217915, 33.595558], [130.217942, 33.595495]
+                            ]
+                        ]
+                    },
+                    "gate_node_ids": [0],
+                },
+                {
+                    "id": 10,
+                    "name": 201,
+                    "coordinate": {
+                        "lat": 33.5954558,
+                        "lng": 130.2179447
+                    },
+                    "floor": 2,
+                    "shape": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [130.217816, 33.595257], [130.217783, 33.595517], [130.217915, 33.595558], [130.217942, 33.595495]
+                            ]
+                        ]
+                    },
+                    "gate_node_ids": [10],
+                    "detail_map_ids": [],
+                    "others": {}
+                },
+            ],
+            "node": [
+                {
+                    "id": 0,
+                    "map_id": 0,
+                    "spot_id": 0,
+                    "coordinate": {
+                        "lat": 33.5954558,
+                        "lng": 130.2179447
+                    },
+                    "floor": 1
+                },
+                {
+                    "id": 10,
+                    "map_id": 0,
+                    "spot_id": 10,
+                    "coordinate": {
+                        "lat": 33.5954558,
+                        "lng": 130.2179447
+                    },
+                    "floor": 2
+                },
+            ],
+            "edge": [
+                {
+                    "id": 0,
+                    "node_id": {
+                        "a": 0,
+                        "b": 10
+                    },
+                    "distance": 1
+                },
+            ],
+            "bounds": {
+                "top_l": {
+                    "lat": 33.5954678,
+                    "lng": 130.2177802
+                },
+                "bot_r": {
+                    "lat": 33.5954678,
+                    "lng": 130.2177802
+                }
             },
-            "floor": 1,
-            "shape": {
-                "type": "Polygon",
-                "coordinates": [
-                    [
-                        [130.217816, 33.595257], [130.217783, 33.595517], [130.217915, 33.595558], [130.217942, 33.595495]
-                    ]
-                ]
-            },
-            "gate_node_ids": [0],
-        },
-        {
-            "id": 10,
-            "name": 201,
-            "coordinate": {
-                "lat": 33.5954558,
-                "lng": 130.2179447
-            },
-            "floor": 2,
-            "shape": {
-                "type": "Polygon",
-                "coordinates": [
-                    [
-                        [130.217816, 33.595257], [130.217783, 33.595517], [130.217915, 33.595558], [130.217942, 33.595495]
-                    ]
-                ]
-            },
-            "gate_node_ids": [10],
-            "detail_map_id": "",
-            "others": {}
-        },
-    ],
-    "node": [
-        {
-            "id": 0,
-            "map_id": 0,
-            "spot_id": 0,
-            "coordinate": {
-                "lat": 33.5954558,
-                "lng": 130.2179447
-            },
-            "floor": 1
-        },
-        {
-            "id": 10,
-            "map_id": 0,
-            "spot_id": 10,
-            "coordinate": {
-                "lat": 33.5954558,
-                "lng": 130.2179447
-            },
-            "floor": 2
-        },
-    ],
-    "edge": [
-        {
-            "id": 0,
-            "node_id": {
-                "a": 0,
-                "b": 10
-            },
-            "distance": 1
-        },
-    ],
-    "bounds": {
-        "top_l": {
-            "lat": 33.5954678,
-            "lng": 130.2177802
-        },
-        "bot_r": {
-            "lat": 33.5954678,
-            "lng": 130.2177802
         }
-    },
+    ]
 }
 module.exports = sougou;

--- a/test/test-examples/sougou-test-map-data.js
+++ b/test/test-examples/sougou-test-map-data.js
@@ -4,7 +4,7 @@ const sougou =
         {
             "id": 0,
             "name": "SougouGakusyuPlaza_1F",
-            "spot": [
+            "spots": [
                 {
                     "id": 0,
                     "name": "101",
@@ -23,7 +23,7 @@ const sougou =
                     "gate_node_ids": [0],
                 }
             ],
-            "node": [
+            "nodes": [
                 {
                     "id": 0,
                     "map_id": 0,
@@ -34,7 +34,7 @@ const sougou =
                     },
                 },
             ],
-            "edge": [
+            "edges": [
                 {
                     "id": 0,
                     "node_id": {
@@ -58,7 +58,7 @@ const sougou =
         {
             "id": 1,
             "name": "SougouGakusyuPlaza_2F",
-            "spot": [
+            "spots": [
                 {
                     "id": 10,
                     "name": "201",
@@ -79,7 +79,7 @@ const sougou =
                     "others": {}
                 }
             ],
-            "node": [
+            "nodes": [
                 {
                     "id": 10,
                     "map_id": 0,
@@ -90,7 +90,7 @@ const sougou =
                     },
                 }
             ],
-            "edge": []
+            "edges": []
         },
     ]
 }


### PR DESCRIPTION
## 実装の概要
- [地図データの仕様](https://www.notion.so/7a6a9ce29e974d5ab2e7d5dfc7f7df2d)
- スポットがもっているdetailMapIdをdetailMapIdsにして配列にする
- スポットに，そのスポットがもっている詳細地図の階層情報の一覧を追加
    - Stringの配列　（['B1', '1F', '2F', '3F']など）
- APIサーバーの更新
- テストデータをスキーマに合わせて更新
- API側のスキーマはマップが配列になってなかったのでそれも変更してます

close #19 